### PR TITLE
Check if third_party folder exists to install etcd

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -117,6 +117,10 @@ kube::etcd::install() {
     os=$(kube::util::host_os)
     arch=$(kube::util::host_arch)
 
+    if [[ ! -d "${KUBE_ROOT}/third_party" ]]; then
+      mkdir "${KUBE_ROOT}/third_party";
+    fi
+
     cd "${KUBE_ROOT}/third_party" || return 1
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
       kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -121,7 +121,7 @@ kube::etcd::install() {
       mkdir "${KUBE_ROOT}/third_party";
     fi
 
-    cd "${KUBE_ROOT}/third_party" || return 1
+    cd "${KUBE_ROOT}/third_party"
     if [[ $(readlink etcd) == etcd-v${ETCD_VERSION}-${os}-* ]]; then
       kube::log::info "etcd v${ETCD_VERSION} already installed. To use:"
       kube::log::info "export PATH=\"$(pwd)/etcd:\${PATH}\""


### PR DESCRIPTION
To avoid error like this.
```
$ ./hack/install-etcd.sh 
$HOME/hyperkube/hack/lib/etcd.sh: line 120: cd: $HOME/hyperkube/third_party: No such file or directory
!!! [1005 04:33:32] Call tree:
!!! [1005 04:33:32]  1: ./hack/install-etcd.sh:28 kube::etcd::install(...)

```